### PR TITLE
Adjust nginx's client_max_body_size to match php's upload_max_filesize

### DIFF
--- a/dokuwiki.conf
+++ b/dokuwiki.conf
@@ -3,6 +3,8 @@ server {
 
     root /var/www;
     index index.php index.html index.htm;
+
+    client_max_body_size 2M;
     
     location / {
         index doku.php;


### PR DESCRIPTION
Right now, the php.ini setting for `upload_max_filesize` is the default, ie. `2M`.
And nginx's `client_max_body_size` is `1M`.
They should both be inline with one another or you get `upload failed` errors when trying to upload files that are above `1M` even though it says that the limit is `2M`right below the file input.

Of course the best would be to make this configurable through env vars.
