### PR TITLE
install php7-xml to avoid utf encode/decode issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV DOKUWIKI_VERSION 2016-06-26a
 ENV MD5_CHECKSUM 9b9ad79421a1bdad9c133e859140f3f2
 
 RUN apk --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ add \
-    php7 php7-fpm php7-gd php7-session nginx supervisor curl tar
+    php7 php7-fpm php7-gd php7-session php7-mbstring nginx supervisor curl tar
 
 RUN mkdir -p /run/nginx && \
     mkdir -p /var/www /var/dokuwiki-storage/data && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV DOKUWIKI_VERSION 2016-06-26a
 ENV MD5_CHECKSUM 9b9ad79421a1bdad9c133e859140f3f2
 
 RUN apk --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ add \
-    php7 php7-fpm php7-gd php7-session php7-mbstring nginx supervisor curl tar
+    php7 php7-fpm php7-gd php7-session php7-xml nginx supervisor curl tar
 
 RUN mkdir -p /run/nginx && \
     mkdir -p /var/www /var/dokuwiki-storage/data && \


### PR DESCRIPTION
Running the install.php script fail with the error message:

> The installer found some problems, indicated below. You can not continue until you have fixed them.
> 
> PHP function utf8_encode is not available. Maybe your hosting provider disabled it for some reason?
> PHP function utf8_decode is not available. Maybe your hosting provider disabled it for some reason?

To solve this, I had to install the php7-xml package.