### PR TITLE
Add chmod for nginx temporary dirs

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+chown -R nobody /var/lib/nginx
+
 chown -R nobody /var/www
 chown -R nobody /var/dokuwiki-storage
 


### PR DESCRIPTION
Hello,
During my test with this image, I encountered the following problem

open() "/var/lib/nginx/tmp/fastcgi/6/00/0000000006" failed (13: Permission denied) while reading upstream, server: , request: "GET /lib/exe/js.php?t=dokuwiki&tseed=9eacfd1f60b051d6f8f HTTP/1.0", upstream: "fastcgi://unix:/var/run/php-fpm7.sock:"

After some debugging, I've discover that during the FPM call made by Nginx, this one need to create some temporaries files into /var/lib/nginx/tmp. But because of the fact that nginx run as 'nobody' user and /var/lib/nginx is restricted to nginx:nginx, it can't perform correctly this request and then the Dokuwiki JS is dead.

Fastly I propose you to change the owner of nginx temporary directories by adding a simple chmod in the start.sh

But I dont really understand why you choose to run the nginx as 'nobody'. The apt package which is responsible of nginx installation create some temporaries directories that belong to the nginx user. Do you think it can be easier to run the nginx process as nginx user ?
