### PR TITLE
Update to alpine 3.6 and latest dokuwiki

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
-FROM alpine:3.5
+FROM alpine:3.6
 MAINTAINER Ilya Stepanov <dev@ilyastepanov.com>
 
 ENV DOKUWIKI_VERSION 2017-02-19b
 ENV MD5_CHECKSUM ea11e4046319710a2bc6fdf58b5cda86
 
-RUN apk --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/3.5/community/ add \
-    php7 php7-fpm php7-gd php7-session php7-xml nginx supervisor curl tar
+RUN apk --no-cache add \
+    php7 php7-openssl php7-zlib php7-mbstring php7-fpm php7-gd php7-session php7-xml nginx \
+    supervisor curl tar
 
 RUN mkdir -p /run/nginx && \
     mkdir -p /var/www /var/dokuwiki-storage/data && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM alpine:3.4
+FROM alpine:3.5
 MAINTAINER Ilya Stepanov <dev@ilyastepanov.com>
 
-ENV DOKUWIKI_VERSION 2016-06-26a
-ENV MD5_CHECKSUM 9b9ad79421a1bdad9c133e859140f3f2
+ENV DOKUWIKI_VERSION 2017-02-19b
+ENV MD5_CHECKSUM ea11e4046319710a2bc6fdf58b5cda86
 
-RUN apk --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ add \
+RUN apk --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/3.5/community/ add \
     php7 php7-fpm php7-gd php7-session php7-xml nginx supervisor curl tar
 
 RUN mkdir -p /run/nginx && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:3.6
 MAINTAINER Ilya Stepanov <dev@ilyastepanov.com>
 
-ENV DOKUWIKI_VERSION 2017-02-19b
-ENV MD5_CHECKSUM ea11e4046319710a2bc6fdf58b5cda86
+ENV DOKUWIKI_VERSION 2017-02-19e
+ENV MD5_CHECKSUM 09bf175f28d6e7ff2c2e3be60be8c65f
 
 RUN apk --no-cache add \
     php7 php7-openssl php7-zlib php7-mbstring php7-fpm php7-gd php7-session php7-xml nginx \

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN echo "cgi.fix_pathinfo = 0;" >> /etc/php7/php-fpm.ini && \
     sed -i -e "s|listen\s*=\s*127\.0\.0\.1:9000|listen = /var/run/php-fpm7.sock|g" /etc/php7/php-fpm.d/www.conf && \
     sed -i -e "s|;listen\.owner\s*=\s*\w*|listen.owner = nginx|g" /etc/php7/php-fpm.d/www.conf && \
     sed -i -e "s|;listen\.group\s*=\s*\w*|listen.group = nginx|g" /etc/php7/php-fpm.d/www.conf && \
-    sed -i -e "s|;user\s*=\s*\w*|user = nginx|g" /etc/php7/php-fpm.d/www.conf && \
+    sed -i -e "s|user\s*=\s*\w*|user = nginx|g" /etc/php7/php-fpm.d/www.conf && \
     sed -i -e "s|;listen\.mode\s*=\s*|listen.mode = |g" /etc/php7/php-fpm.d/www.conf && \
     chmod +x /start.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,8 @@ ADD start.sh /start.sh
 RUN echo "cgi.fix_pathinfo = 0;" >> /etc/php7/php-fpm.ini && \
     sed -i -e "s|;daemonize\s*=\s*yes|daemonize = no|g" /etc/php7/php-fpm.conf && \
     sed -i -e "s|listen\s*=\s*127\.0\.0\.1:9000|listen = /var/run/php-fpm7.sock|g" /etc/php7/php-fpm.d/www.conf && \
-    sed -i -e "s|;listen\.owner\s*=\s*|listen.owner = |g" /etc/php7/php-fpm.d/www.conf && \
-    sed -i -e "s|;listen\.group\s*=\s*|listen.group = |g" /etc/php7/php-fpm.d/www.conf && \
+    sed -i -e "s|;listen\.owner\s*=\s*\w*|listen.owner = nginx|g" /etc/php7/php-fpm.d/www.conf && \
+    sed -i -e "s|;listen\.group\s*=\s*\w*|listen.group = nginx|g" /etc/php7/php-fpm.d/www.conf && \
     sed -i -e "s|;listen\.mode\s*=\s*|listen.mode = |g" /etc/php7/php-fpm.d/www.conf && \
     chmod +x /start.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN echo "cgi.fix_pathinfo = 0;" >> /etc/php7/php-fpm.ini && \
     sed -i -e "s|listen\s*=\s*127\.0\.0\.1:9000|listen = /var/run/php-fpm7.sock|g" /etc/php7/php-fpm.d/www.conf && \
     sed -i -e "s|;listen\.owner\s*=\s*\w*|listen.owner = nginx|g" /etc/php7/php-fpm.d/www.conf && \
     sed -i -e "s|;listen\.group\s*=\s*\w*|listen.group = nginx|g" /etc/php7/php-fpm.d/www.conf && \
+    sed -i -e "s|;user\s*=\s*\w*|user = nginx|g" /etc/php7/php-fpm.d/www.conf && \
     sed -i -e "s|;listen\.mode\s*=\s*|listen.mode = |g" /etc/php7/php-fpm.d/www.conf && \
     chmod +x /start.sh
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,6 +1,6 @@
 daemon off;
 
-user nobody;
+user nginx;
 worker_processes  1;
 
 error_log  stderr error;

--- a/start.sh
+++ b/start.sh
@@ -2,9 +2,9 @@
 
 set -e
 
-chown -R nobody /var/www
-chown -R nobody /var/dokuwiki-storage
+chown -R nginx /var/www
+chown -R nginx /var/dokuwiki-storage
 
-su -s /bin/sh nobody -c 'php7 /var/www/bin/indexer.php -c'
+su -s /bin/sh nginx -c 'php7 /var/www/bin/indexer.php -c'
 
 exec /usr/bin/supervisord -c /etc/supervisord.conf


### PR DESCRIPTION
Updated to alpine 3.6 (solves PHP bug in alpine 3.5: https://github.com/docker-library/php/issues/376) and dokuwiki 2017-02-19b.

Docker image running these changes is here: https://hub.docker.com/r/julakali/dokuwiki/

Added php7-openssl and php7-zlib for extension downloads and php7-mbstring to support the Dw2Pdf extension.